### PR TITLE
Feature/eslint8

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+# PR Title
+
+## Feature Check List
+
+- [ ] feature1
+- [ ] feature2
+- [ ] feature3
+
+## Other Feedbacks
+
+- feeds

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@ NPM: [https://www.npmjs.com/package/eslint-plugin-barrel-rules](https://www.npmj
 **eslint-plugin-barrel-rules**는  
 JavaScript/TypeScript 프로젝트에서 Barrel Pattern(배럴 패턴)을 강제하고, 모듈 경계와 캡슐화를 보장하는 고급 ESLint 플러그인입니다.
 
-지정한 디렉토리(예: `src/domains/*`)의 내부 구현은  
+지정한 디렉토리(예: `src/domains/*`, `src/domains/cart`)의 내부 구현은  
 오직 해당 디렉토리의 **index(배럴) 파일**을 통해서만 접근할 수 있도록 강제합니다.  
 내부 파일을 직접 import하는 것을 차단하여  
 **모듈화, 추상화, 유지보수성, 확장성**을 극대화합니다.
@@ -32,10 +32,12 @@ JavaScript/TypeScript 프로젝트에서 Barrel Pattern(배럴 패턴)을 강제
 
 ## 지원 환경
 
-- ESLint 9 (Flat config, 현재 지원)
-  > ⚠️ ESLint 8 (구 config) 지원도 곧 추가될 예정입니다!
-- Node.js (ES2015+)
-- ES Modules (ESM) 지원
+- ESLint 9
+  > Flat config(eslint.config.js), TypeScript 지원 시 "typescript-eslint" config 사용 필요
+- ESLint 8
+  > Legacy config(.eslintrc.js), TypeScript 지원 시 "@typescript-eslint/parser"를 parser로 지정하고, "@typescript-eslint"를 plugin에 추가해야 함
+- Node.js (ES2015 이상)
+- ES 모듈, CommonJS 모듈 모두 지원
 
 ---
 
@@ -63,39 +65,77 @@ pnpm add -D eslint-plugin-barrel-rules
 
 ---
 
-## 사용법
+## Eslint8 사용법
 
 ```js
+file(.eslintrc.js)
+
+module.exports = {
+  ...(any other options)
+  // 타입스크립트를 사용할 경우 "@typescript-eslint/parser", "@typescript-eslint"를 설치하고 설정해 주세요.
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint", "barrel-rules"],
+  rules: {
+    "barrel-rules/enforce-barrel-pattern": [
+      "error",
+      {
+        // 배럴 파일로 보호할 디렉토리의 경로입니다. baseDir을 기준으로 상대 경로로 설정합니다.
+        paths: ["src/typescript/barrel/*", "src/javascript/barrel/*"],
+        // (옵션) 설정하지 않으면 기본값은 ESLint를 실행한 위치(작업 디렉토리)입니다.
+        // 예: `npx eslint .`처럼 실행하면, 실행 시점의 현재 디렉토리가 기본값이 됩니다.
+        baseDir: __dirname,
+      },
+    ],
+  },
+};
+```
+
+---
+
+## Eslint9 사용법
+
+```js
+file(eslintrc.config.js);
+
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import { globalIgnores } from "eslint/config";
+import barrelRules from "eslint-plugin-barrel-rules";
+// ESM에서 __dirname을 사용하기 위한 코드
 import { fileURLToPath } from "url";
 import path from "path";
-import { enforceBarrelPattern } from "eslint-plugin-barrel-rules";
-
-//ESM은 __dirname을 지원하지 않기에 직접 구현합니다.
+// 커스텀 __dirname 생성
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
-export default [
+// 타입스크립트 사용 시 필요
+export default tseslint.config([
+  globalIgnores(["dist"]),
   {
-    plugins: {
-      "barrel-rules": {
-        rules: {
-          "enforce-barrel-pattern": enforceBarrelPattern,
-        },
-      },
+    // (다른 옵션들 추가 가능)
+    files: ["**/*.{ts,tsx}"],
+    extends: [js.configs.recommended, tseslint.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 2020,
     },
+    // barrel-rules 플러그인만 추가하면 됩니다.
+    plugins: {
+      "barrel-rules": barrelRules,
+    },
+    // barrel-rules에 대한 설정만 추가하면 됩니다.
     rules: {
       "barrel-rules/enforce-barrel-pattern": [
         "error",
         {
-          //Barrel Pattern을 강제할 디렉토리를 정의합니다(baseDir 기준으로 상대경로)
-          paths: ["src/domains/*"],
-          //paths들의 root경로를 지정합니다.
+          // 배럴 파일로 보호할 디렉토리의 경로입니다. baseDir을 기준으로 상대 경로로 설정합니다.
+          paths: ["src/typescript/barrel/*"],
+          // (옵션) 설정하지 않으면 기본값은 ESLint를 실행한 위치(작업 디렉토리)입니다.
+          // 예: `npx eslint .`처럼 실행하면, 실행 시점의 현재 디렉토리가 기본값이 됩니다.
           baseDir: __dirname,
         },
       ],
     },
   },
-];
+]);
 ```
 
 ---
@@ -115,15 +155,15 @@ import { Test } from "../domains/foo";
 ## 앞으로의 계획
 
 - 더 다양한 모듈 경계/추상화 관련 룰 추가 예정
-
-- **Alias/tsconfig 지원**  
-  TypeScript `paths`, Vite `resolve.alias` 등 다양한 경로 매핑 완벽 지원 예정
-
-- **Commonjs 지원**
+- Alias/tsconfig 지원: TypeScript의 paths, Vite의 resolve.alias, 기타 커스텀 경로 매핑을 완벽하게 지원
+- **CJS 지원** (OK)
+- **ESLint 8 지원** (OK)
+- **번들 플러그인(플러그인 내 모든 기능 통합)** (OK)
+- **잘못된 경로 설정 검증 기능** (OK)
 
 ---
 
 ## 문의
 
 질문, 제안, 버그 리포트, 기여 모두 환영합니다!  
-[[📬 send mail]](mailto:lhsung98@naver.com)
+[[📬 send mail lhsung98@naver.com]](mailto:lhsung98@naver.com)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ NPM: [https://www.npmjs.com/package/eslint-plugin-barrel-rules](https://www.npmj
 that enforces the Barrel Pattern in JavaScript/TypeScript projects,  
 ensuring strict module boundaries and encapsulation.
 
-You can specify directories (e.g., `src/domains/*`) where  
+You can specify directories (e.g., `src/domains/*`, `src/domains/cart`) where  
 internal implementation details must only be accessed via the directory’s **index (barrel) file**.  
 Direct imports from internal files are blocked, maximizing  
 **modularity, abstraction, maintainability, and scalability**.
@@ -35,10 +35,12 @@ Direct imports from internal files are blocked, maximizing
 
 ## Supports
 
-- ESLint 9 (Flat config, currently supported)
-  > ⚠️ ESLint 8 (legacy config) support is planned for a future release!
+- ESLint 9
+  > Flat config(eslint.config.js), for TypeScript support, use the "typescript-eslint" config
+- ESLint 8
+  > Legacy config(.eslintrc.js), for TypeScript support, set "@typescript-eslint/parser" as the parser and add "@typescript-eslint" as a plugin
 - Node.js (ES2015+)
-- Supports ES Modules (ESM)
+- Supports both ES Modules and CommonJS
 
 ---
 
@@ -66,39 +68,77 @@ pnpm add -D eslint-plugin-barrel-rules
 
 ---
 
-## Usage
+## Eslint8 Usage
 
 ```js
+file(.eslintrc.js)
+
+module.exports = {
+  ...(any other options)
+  //if you use typescript, needs "@typescript-eslint/parser", "@typescript-eslint" install and setup plz..
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint", "barrel-rules"],
+  rules: {
+    "barrel-rules/enforce-barrel-pattern": [
+      "error",
+      {
+        // The path to the directory that should be protected by using a barrel file. This path is relative to baseDir.
+        paths: ["src/typescript/barrel/*", "src/javascript/barrel/*"],
+        // Optional config. The default value is the directory where ESLint is executed.
+// For example, if you run `npx eslint .`, the default will be the current working directory at the time of execution.
+        baseDir: __dirname,
+      },
+    ],
+  },
+};
+```
+
+---
+
+## Eslint9 Usage
+
+```js
+file(eslintrc.config.js);
+
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import { globalIgnores } from "eslint/config";
+import barrelRules from "eslint-plugin-barrel-rules";
+//for __dirname in ESM
 import { fileURLToPath } from "url";
 import path from "path";
-import { enforceBarrelPattern } from "eslint-plugin-barrel-rules";
-
-//ESM not support __dirname(custom __dirname)
+//custom __dirname
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
-export default [
+//typescript-config (if you use typescript, needs it)
+export default tseslint.config([
+  globalIgnores(["dist"]),
   {
-    plugins: {
-      "barrel-rules": {
-        rules: {
-          "enforce-barrel-pattern": enforceBarrelPattern,
-        },
-      },
+    ...(any other options)
+    files: ["**/*.{ts,tsx}"],
+    extends: [js.configs.recommended, tseslint.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 2020,
     },
+    //just set barrle-rules plugin
+    plugins: {
+      "barrel-rules": barrelRules,
+    },
+    //just set your setting for barrel-rules
     rules: {
       "barrel-rules/enforce-barrel-pattern": [
         "error",
         {
-          //Enforced directories
-          paths: ["src/domains/*"],
-          //BaseDir(root path, mutable)
+          // The path to the directory that should be protected by using a barrel file. This path is relative to baseDir.
+          paths: ["src/typescript/barrel/*"],
+          // Optional config. The default value is the directory where ESLint is executed.
+          // For example, if you run `npx eslint .`, the default will be the current working directory at the time of execution.
           baseDir: __dirname,
         },
       ],
     },
   },
-];
+]);
 ```
 
 ---
@@ -122,11 +162,15 @@ import { Test } from "../domains/foo";
 - **Alias/tsconfig Support**  
   Fully supports TypeScript `paths`, Vite `resolve.alias`, and other custom path mappings
 
-- **CJS Support**
+- **CJS Support** (OK)
+- **Eslint8 Support** (OK)
+- **Bundle Plugin(capsure any features in plugin)**
+  (OK)
+- **Wrong Path Setup Validator** (OK)
 
 ---
 
 ## Contact
 
 Questions, suggestions, bug reports, and contributions are welcome!  
-[[📬 send mail]](mailto:lhsung98@naver.com)
+[[📬 send mail lhsung98@naver.com]](mailto:lhsung98@naver.com)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 import { enforceBarrelPattern } from "./rules/enforce-barrel-pattern";
 
-export { enforceBarrelPattern };
+const rules = {
+  "enforce-barrel-pattern": enforceBarrelPattern,
+};
 
-//CJS 지원
-// export default {
-//     rules: {
-//       "enforce-barrel-pattern": enforceBarrelPattern,
-//     },
-//   };
+// ESM(eslint9+)
+export default { rules };
+
+// // CJS(eslint8+)
+module.exports = { rules };

--- a/src/rules/enforce-barrel-pattern.ts
+++ b/src/rules/enforce-barrel-pattern.ts
@@ -20,6 +20,7 @@ const enforceBarrelPattern: RuleModule<MessageIds, Option[]> = {
           paths: { type: "array", items: { type: "string" } },
           baseDir: { type: "string" },
         },
+        required: ["paths"],
         additionalProperties: false,
       },
     ],
@@ -34,7 +35,6 @@ const enforceBarrelPattern: RuleModule<MessageIds, Option[]> = {
     //extract options
     const option = context.options[0];
     const baseDir = option.baseDir;
-
     //get target paths(allowed wildcard with fast-glob)
     const targetPaths = option.paths.flatMap((_path) => {
       //get target paths with fast-glob(directory names)
@@ -51,7 +51,6 @@ const enforceBarrelPattern: RuleModule<MessageIds, Option[]> = {
       }
       return globResult;
     });
-
     return {
       //check only import declaration(ESM)
       ImportDeclaration(node: TSESTree.ImportDeclaration) {


### PR DESCRIPTION
# Eslint8 Support

## Feature Check List

- [x] bundle plugin(rules, etc as default one file)
- [x] cjs,esm support(CJS eslint8, ESM eslint9)
- [x] update docs(new usage of setup, typescript dependency, updated features)
- [x] change baseDir as optional config

## Other Feedbacks

- support eslint8(CJS) and eslint9(ESM! 
- baseDir is not powerfiul, so changed it as optional config. but beware default value current working directory. so without baseDir, you need to execut eslint in root directory! 

