### PR TITLE
Feature/wildcard import

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -53,6 +53,22 @@ JavaScript/TypeScript 프로젝트에서 Barrel Pattern(배럴 패턴)을 강제
 
 ---
 
+## 규칙(Rules)
+
+1. **enforce-barrel-pattern**  
+   모듈 임포트 시 배럴 패턴(Barrel Pattern)을 강제합니다.  
+   지정한 배럴 파일을 통해서만 임포트가 가능하며, 내부 모듈에 직접 접근하는 것을 방지합니다.
+
+   - **옵션:**
+     - `paths`: 배럴 패턴으로 보호할 디렉토리 경로(`baseDir` 기준 상대경로)
+     - `baseDir` (선택): `paths` 해석 기준이 되는 디렉토리. 기본값은 ESLint 실행 위치입니다.
+
+2. **no-wildcard**  
+   `import * as foo from "module"`, `export * from "./module"`과 같은 와일드카드(네임스페이스) import/export를 금지합니다.  
+   트리쉐이킹 및 코드 명확성을 위해 반드시 개별(named) import/export만 허용합니다.
+
+---
+
 ## 설치
 
 ```bash
@@ -86,6 +102,8 @@ module.exports = {
         baseDir: __dirname,
       },
     ],
+    // import * 또는 export * 금지
+    "barrel-rules/no-wildcard": ["error"],
   },
 };
 ```
@@ -133,6 +151,8 @@ export default tseslint.config([
           baseDir: __dirname,
         },
       ],
+      // import * 또는 export * 금지
+      "barrel-rules/no-wildcard": ["error"],
     },
   },
 ]);
@@ -154,12 +174,13 @@ import { Test } from "../domains/foo";
 
 ## 앞으로의 계획
 
-- 더 다양한 모듈 경계/추상화 관련 룰 추가 예정
-- Alias/tsconfig 지원: TypeScript의 paths, Vite의 resolve.alias, 기타 커스텀 경로 매핑을 완벽하게 지원
+- 더 다양한 모듈 경계/추상화 관련 룰 추가 예정 (~Ing)
+- Alias/tsconfig 지원: TypeScript의 paths, Vite의 resolve.alias, 기타 커스텀 경로 매핑을 완벽하게 지원 (~Ing)
 - **CJS 지원** (OK)
 - **ESLint 8 지원** (OK)
 - **번들 플러그인(플러그인 내 모든 기능 통합)** (OK)
 - **잘못된 경로 설정 검증 기능** (OK)
+- **와일드카드 import/export 제한 규칙** (OK)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ Direct imports from internal files are blocked, maximizing
 
 ---
 
+## Rules
+
+1. **enforce-barrel-pattern**  
+   Enforces the barrel pattern for module imports.  
+   Only allows imports from designated barrel files and prevents direct access to internal modules.
+
+   - **Options:**
+     - `paths`: The directories to be protected by the barrel pattern (relative to `baseDir`).
+     - `baseDir` (optional): The base directory for resolving `paths`. Defaults to the ESLint execution directory.
+
+2. **no-wildcard**  
+   Disallows wildcard (namespace) imports such as `import * as foo from "module"`, `export * from "./module"`
+   Forces you to use named imports for better tree-shaking and code clarity.
+
+---
+
 ## Install
 
 ```bash
@@ -89,6 +105,8 @@ module.exports = {
         baseDir: __dirname,
       },
     ],
+    // Disallow wildcard (namespace) import/export.
+    "barrel-rules/no-wildcard": ["error"],
   },
 };
 ```
@@ -136,6 +154,8 @@ export default tseslint.config([
           baseDir: __dirname,
         },
       ],
+      // Disallow wildcard (namespace) import/export.
+      "barrel-rules/no-wildcard": ["error"],
     },
   },
 ]);
@@ -157,16 +177,17 @@ import { Test } from "../domains/foo";
 
 ## Future Work
 
-- More rules for module boundaries and abstraction
+- More rules for module boundaries and abstraction (~Ing)
 
 - **Alias/tsconfig Support**  
-  Fully supports TypeScript `paths`, Vite `resolve.alias`, and other custom path mappings
+  Fully supports TypeScript `paths`, Vite `resolve.alias`, and other custom path mappings (~Ing)
 
 - **CJS Support** (OK)
 - **Eslint8 Support** (OK)
 - **Bundle Plugin(capsure any features in plugin)**
   (OK)
 - **Wrong Path Setup Validator** (OK)
+- **Wildcard Import/Export Protection Rule** (OK)
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 import { enforceBarrelPattern } from "./rules/enforce-barrel-pattern";
+import { noWildcard } from "./rules/no-wildcard";
 
 const rules = {
   "enforce-barrel-pattern": enforceBarrelPattern,
+  "no-wildcard": noWildcard,
 };
 
 // ESM(eslint9+)

--- a/src/rules/enforce-barrel-pattern.ts
+++ b/src/rules/enforce-barrel-pattern.ts
@@ -5,9 +5,9 @@ import resolve from "resolve";
 import fastGlob from "fast-glob";
 
 type Option = { paths: string[]; baseDir: string };
-type MessageIds = "DirectImportDisallowed";
+type DirectImportMessageId = "DirectImportDisallowed";
 
-const enforceBarrelPattern: RuleModule<MessageIds, Option[]> = {
+const enforceBarrelPattern: RuleModule<DirectImportMessageId, Option[]> = {
   meta: {
     type: "problem",
     docs: {

--- a/src/rules/no-wildcard.ts
+++ b/src/rules/no-wildcard.ts
@@ -1,0 +1,49 @@
+import { TSESTree } from "@typescript-eslint/utils";
+import type { RuleModule } from "@typescript-eslint/utils/ts-eslint";
+
+type NoWildcardImportMessageId = "NoWildcardImport";
+type NoExportAllMessageId = "NoExportAll";
+
+const noWildcard: RuleModule<
+  NoWildcardImportMessageId | NoExportAllMessageId,
+  []
+> = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Wildcard (namespace) import is not allowed.",
+    },
+    schema: [],
+    messages: {
+      NoWildcardImport:
+        "Wildcard import (`import * as ... from ...`) is not allowed. Please use named imports instead.",
+      NoExportAll:
+        "Export all (`export * from ...`) is not allowed. Please use named exports instead.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        //check if the import is a wildcard import
+        const hasNamespaceImport = node.specifiers.some(
+          (specifier) => specifier.type === "ImportNamespaceSpecifier"
+        );
+        if (hasNamespaceImport) {
+          context.report({
+            node,
+            messageId: "NoWildcardImport",
+          });
+        }
+      },
+      ExportAllDeclaration(node: TSESTree.ExportAllDeclaration) {
+        context.report({
+          node,
+          messageId: "NoExportAll",
+        });
+      },
+    };
+  },
+};
+
+export { noWildcard };


### PR DESCRIPTION
# no-wildcard (Rule)

## Feature Check List

- [x] protect wildcard import (ex. import * as foo from "bar")
- [x] protect wildcard export (ex. export * from "bar")
- [x] capsure 'no-wildcard' rule in plugin
- [x] usage update in docs

## Other Feedbacks
Wildcard import/export is a pattern that often occurs when using the barrel pattern. However, it is considered an anti-pattern because it makes it difficult to track internal implementations and often brings in unnecessary features, which can negatively impact tree-shaking and overall performance. To fully leverage the benefits of the barrel pattern, it is important to avoid wildcard import/export. Therefore, I have added a rule to prevent this usage.
